### PR TITLE
#60 seed publish tag deconfliction. 

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -17,10 +17,8 @@ import (
 func DockerBuild(jobDirectory string) error {
 
 	seedFileName, err := util.SeedFileName(jobDirectory)
-	if err != nil && os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "ERROR: %s cannot be found.\n",
-			seedFileName)
-		fmt.Fprintf(os.Stderr, "Make sure you have specified the correct directory.\n")
+	if err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err.Error())
 		return err
 	}
 

--- a/commands/build_test.go
+++ b/commands/build_test.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -48,8 +47,8 @@ func TestSeedLabel(t *testing.T) {
 
 	for _, c := range cases {
 		DockerBuild(c.directory)
-		seedFileName, er := util.SeedFileName(c.directory)
-		if er != nil && os.IsNotExist(er) {
+		seedFileName, exist, _ := util.GetSeedFileName(c.directory)
+		if !exist {
 			t.Errorf("ERROR: %s cannot be found.\n",
 				seedFileName)
 			t.Errorf("Make sure you have specified the correct directory.\n")

--- a/commands/publish.go
+++ b/commands/publish.go
@@ -20,7 +20,6 @@ import (
 //DockerPublish executes the seed publish command
 func DockerPublish(origImg, registry, org, jobDirectory string, deconflict,
 	increasePkgMinor, increasePkgMajor, increaseAlgMinor, increaseAlgMajor bool) error {
-
 	//1. Check names and verify it doesn't conflict
 	tag := ""
 	img := origImg
@@ -38,19 +37,19 @@ func DockerPublish(origImg, registry, org, jobDirectory string, deconflict,
 	}
 
 	// Check for image confliction.
-	// existing, err := DockerSearch(registry, org, "", "", "")
-	// _ = err
-	// conflict := len(existing) > 0
-	conflict := false //TODO - Need to call seed search when implemented
+	matches, err := DockerSearch(registry, org, origImg, "", "")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Error searching for matching tag names.\n%s\n",
+			err.Error())
+	}
+	conflict := len(matches) > 0
 
 	// If it conflicts, bump specified version number
 	if conflict && deconflict {
 		//1. Verify we have a valid manifest (-d option or within the current directory)
 		seedFileName, err := util.SeedFileName(jobDirectory)
-		if err != nil && os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "ERROR: %s cannot be found.\n",
-				seedFileName)
-			fmt.Fprintf(os.Stderr, "Make sure you have specified the correct directory.\n")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ERROR: %s\n", err.Error())
 			return err
 		}
 		ValidateSeedFile("", seedFileName, constants.SchemaManifest)

--- a/commands/search.go
+++ b/commands/search.go
@@ -13,7 +13,7 @@ import (
 )
 
 //DockerSearch executes the seed search command
-func DockerSearch(url, org, filter, username, password string) error {
+func DockerSearch(url, org, filter, username, password string) ([]string, error) {
 	_ = filter //TODO: add filter
 
 	if url == "" {
@@ -36,37 +36,44 @@ func DockerSearch(url, org, filter, username, password string) error {
 		hub, err := dockerHubRegistry.New(url)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, err.Error())
-			return err
+			return nil, err
 		}
 		repositories, err = hub.UserRepositories(org)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, err.Error())
-			return err
+			return nil, err
 		}
 	} else {
 		hub, err := registry.New(url, username, password)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, err.Error())
-			return err
+			return nil, err
 		}
 		repositories, err = hub.Repositories()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, err.Error())
-			return err
+			return nil, err
 		}
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, err.Error())
-		return err
+		return nil, err
 	}
 
+	var stringRepos []string
 	for _, repo := range repositories {
-		if strings.HasSuffix(repo, "-seed") {
-			fmt.Println(repo)
+		if strings.Contains(repo, "-seed") {
+			if filter != "" {
+				if strings.Contains(repo, filter) {
+					stringRepos = append(stringRepos, repo)
+				}
+			} else {
+				stringRepos = append(stringRepos, repo)
+			}
 		}
 	}
 
-	return nil
+	return stringRepos, nil
 }
 
 //PrintSearchUsage prints the seed search usage information, then exits the program

--- a/commands/validate.go
+++ b/commands/validate.go
@@ -19,10 +19,8 @@ func Validate(schemaFile, dir string) error {
 	var seedFileName string
 
 	seedFileName, err = util.SeedFileName(dir)
-	if err != nil && os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "ERROR: %s cannot be found.\n",
-			seedFileName)
-		fmt.Fprintf(os.Stderr, "Make sure you have specified the correct directory.\n")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err.Error())
 		return err
 	}
 

--- a/dockerHubRegistry/json.go
+++ b/dockerHubRegistry/json.go
@@ -3,10 +3,13 @@ package dockerHubRegistry
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
+	"os"
 )
 
 var (
+	//ErrNoMorePages error representing no more pages
 	ErrNoMorePages = errors.New("No more pages")
 )
 
@@ -25,6 +28,7 @@ func (registry *DockerHubRegistry) getDockerHubPaginatedJson(url string, respons
 	err = decoder.Decode(response)
 	r := response.(*repositoriesResponse)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "Returning error")
 		return "", err
 	}
 	if r.Next == "" {

--- a/dockerHubRegistry/registry.go
+++ b/dockerHubRegistry/registry.go
@@ -6,11 +6,13 @@ import (
 	"strings"
 )
 
+//DockerHubRegistry type representing a Docker Hub registry
 type DockerHubRegistry struct {
 	URL    string
 	Client *http.Client
 }
 
+//New creates a new docker hub registry from the given URL
 func New(registryUrl string) (*DockerHubRegistry, error) {
 	url := strings.TrimSuffix(registryUrl, "/")
 	registry := &DockerHubRegistry{

--- a/dockerHubRegistry/repositories.go
+++ b/dockerHubRegistry/repositories.go
@@ -7,10 +7,12 @@ type repositoriesResponse struct {
 	Results  []Result
 }
 
+//Result struct representing JSON result
 type Result struct {
 	Name string
 }
 
+//UserRepositories Returns repositories for the given user
 func (registry *DockerHubRegistry) UserRepositories(user string) ([]string, error) {
 	url := registry.url("/v2/repositories/%s/", user)
 	repos := make([]string, 0, 10)
@@ -20,7 +22,33 @@ func (registry *DockerHubRegistry) UserRepositories(user string) ([]string, erro
 		response.Next = ""
 		url, err = registry.getDockerHubPaginatedJson(url, &response)
 		for _, r := range response.Results {
-			repos = append(repos, r.Name)
+			// Add all tags if found
+			if rs, _ := registry.UserRepositoriesTags(user, r.Name); len(rs) > 0 {
+				repos = append(repos, rs...)
+
+				// No tags found - so just add the repo name
+			} else {
+				repos = append(repos, r.Name)
+			}
+		}
+	}
+	if err != ErrNoMorePages {
+		return nil, err
+	}
+	return repos, nil
+}
+
+//UserRepositoriesTags Returns repositories along with their tags
+func (registry *DockerHubRegistry) UserRepositoriesTags(user string, repository string) ([]string, error) {
+	url := registry.url("/v2/repositories/%s/%s/tags", user, repository)
+	repos := make([]string, 0, 10)
+	var err error //We create this here, otherwise url will be rescoped with :=
+	var response repositoriesResponse
+	for err == nil {
+		response.Next = ""
+		url, err = registry.getDockerHubPaginatedJson(url, &response)
+		for _, r := range response.Results {
+			repos = append(repos, repository+":"+r.Name)
 		}
 	}
 	if err != ErrNoMorePages {

--- a/main.go
+++ b/main.go
@@ -112,9 +112,18 @@ func main() {
 		filter := searchCmd.Lookup(constants.FilterFlag).Value.String()
 		username := searchCmd.Lookup(constants.UserFlag).Value.String()
 		password := searchCmd.Lookup(constants.PassFlag).Value.String()
-		err := commands.DockerSearch(url, org, filter, username, password)
+		results, err := commands.DockerSearch(url, org, filter, username, password)
 		if err != nil {
 			panic(util.Exit{1})
+		}
+
+		if len(results) > 0 {
+			fmt.Fprintf(os.Stderr, "Found %v Repositories:\n", len(results))
+			for _, r := range results {
+				fmt.Fprintf(os.Stderr, "%s\n", r)
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "No repositories found.\n")
 		}
 		panic(util.Exit{0})
 	}
@@ -379,7 +388,7 @@ func DefineFlags() {
 		PrintUsage()
 	}
 
-	var cmd *flag.FlagSet = nil
+	var cmd *flag.FlagSet
 	minArgs := 2
 
 	// Parse commands
@@ -389,7 +398,7 @@ func DefineFlags() {
 
 		// Check for seed manifest in current directory. If found, add current directory arg
 		if len(os.Args) == 2 {
-			if _, err := util.SeedFileName("."); err == nil {
+			if _, exist, err := util.GetSeedFileName("."); err == nil && exist {
 				os.Args = append(os.Args, ".")
 			}
 		}


### PR DESCRIPTION
Modified the seed search code to include filtering and to return a list of repositories - including each tag of a matching repository.
Assumes the search filter doesn't require key=value format and just does a `strings.Contains` on the resulting repositories set. Also does not take into account a username or password. 

Calls `seed search` with 
`results, error := DockerSearch(registry, org, "imageName:tag", "", "")`