### PR TITLE
#168

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -157,7 +157,7 @@ func DockerRun(imageName, outputDir, metadataSchema string, inputs, json, settin
 	dockerRun := exec.Command("docker", dockerArgs...)
 	var errs bytes.Buffer
 	if !quiet {
-		dockerRun.Stderr = io.MultiWriter(&errs)
+		dockerRun.Stderr = io.MultiWriter(&errs, os.Stderr)
 		dockerRun.Stdout = os.Stderr
 	}
 
@@ -193,7 +193,7 @@ func DockerRun(imageName, outputDir, metadataSchema string, inputs, json, settin
 	}
 
 	if errs.String() != "" {
-		util.PrintUtil("stderr out for '%s':\n%s\n",
+		util.PrintUtil("stderr for '%s':\n%s\n",
 			imageName, errs.String())
 	}
 

--- a/testdata/stderr-output/run.sh
+++ b/testdata/stderr-output/run.sh
@@ -10,8 +10,14 @@ echo 'Input file is  ' ${INPUT}
 echo 'output file is ' ${OUTPUT}
 echo '----------------------------------------------------'
 echo 'this is stdout'
+sleep 2
 >&2 echo 'this is stderr'
+sleep 2
 echo '----------------------------------------------------'
+echo 'this is stdout again'
+sleep 2
+>&2 echo 'this is stderr again'
+sleep 2
 echo ''
 touch ${OUTPUT}/my_output.txt
 exit 0


### PR DESCRIPTION
fixes #168 
this writes out anything from stderr alongside stdout. Unfortunately os/exec does not provide a combined output stream, so if the output is rapidfire, there is a race condition that might cause the lines to be printed out of order. 