### PR TITLE
#171 Removing default assigning of blank organization

### DIFF
--- a/commands/search.go
+++ b/commands/search.go
@@ -18,10 +18,6 @@ func DockerSearch(url, org, filter, username, password string) ([]string, error)
 		url = common_const.DefaultRegistry
 	}
 
-	if org == "" {
-		org = common_const.DefaultOrg
-	}
-
 	registry, err := RegistryFactory.CreateRegistry(url, org, username, password)
 	if registry != nil && err == nil {
 		images, err := registry.Images()


### PR DESCRIPTION
Fixes #171 
Since not all registries require an organization, we removed the default organization being set in DockerSearch in order to resolve 'false errors' being displayed during a `seed publish`.