### PR TITLE
#189 reducing ascii art size

### DIFF
--- a/main.go
+++ b/main.go
@@ -826,6 +826,6 @@ func PrintVersion() {
 //PrintAsciiArt prints the ascii art before any seed help
 func PrintASCIIArt() {
 	imgBytes, _ := assets.Asset("images/wordmark.png")
-	a, _ := ascii.Decode(bytes.NewReader(imgBytes), ascii.Options{Color: true})
+	a, _ := ascii.Decode(bytes.NewReader(imgBytes), ascii.Options{Color: true, Height: 12})
 	a.WriteTo(os.Stdout)
 }


### PR DESCRIPTION
Reduced the ascii art size so it doesn't fill the width of the terminal

<img width="1156" alt="screen shot 2018-10-25 at 9 35 13 am" src="https://user-images.githubusercontent.com/29577288/47503963-507e7380-d839-11e8-8bd4-f4bf7e8afc70.png">
