### PR TITLE
Fixing multi file temp directory reference in command arguments

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -286,7 +286,7 @@ func DefineInputs(seed *objects.Seed, inputs []string) ([]string, float64, map[s
 		// Handle replacing KEY or ${KEY} or $KEY
 		value := val
 		if directory, ok := tempDirectories[key]; ok {
-			value = directory //replace with the temp directory if multiple files
+			value = "/" + directory //replace with the temp directory located at the root if multiple files
 		}
 		seed.Job.Interface.Command = strings.Replace(seed.Job.Interface.Command,
 			"${"+key+"}", value, -1)


### PR DESCRIPTION
Command arguments were missing the '/' when the input data keys are replaced for multiple inputs. This resulted in the files being mounted in a temp directory located at the root, but not referenced with the preceding '/' when being passed to the container as arguments. 