### PR TITLE
Adding the spec command implementation

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -14,6 +14,7 @@ const RunCommand = "run"
 const SearchCommand = "search"
 const ValidateCommand = "validate"
 const VersionCommand = "version"
+const SpecCommand = "spec"
 
 //CacheFromFlag defines the docker cache-from option to utilize a previous built image
 const CacheFromFlag = "cache-from"


### PR DESCRIPTION
Implementation of the seed spec command. This was implemented in branch 140 but git wasn't letting me create a PR from that branch.

Addresses #140 and #197 