### PR TITLE
#202 - Publish Overwrites without Login

### DIFF
--- a/commands/publish.go
+++ b/commands/publish.go
@@ -75,6 +75,7 @@ func DockerPublish(origImg, registry, org, username, password, jobDirectory stri
 	if err != nil {
 		util.PrintUtil("ERROR: Error searching for matching tag names.\n%s\n",
 			err.Error())
+		return err
 	}
 	conflict := util.ContainsString(images, origImg) || util.ContainsString(images, orgImg)
 	if conflict {


### PR DESCRIPTION
The publish command will now return an error if one occurs when searching for existing images.