### PR TITLE
Remove debug output and link to user guide

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -244,7 +244,6 @@ func DefineInputs(seed *objects.Seed, inputs []string) ([]string, float64, map[s
 	tempDirectories = make(map[string]string)
 	for _, f := range seed.Job.Interface.Inputs.Files {
 		normalName := util.GetNormalizedVariable(f.Name)
-		util.PrintUtil("normalName: %s\n", normalName)
 		if f.Multiple {
 			tempDir := "temp-" + time.Now().Format(time.RFC3339)
 			tempDir = strings.Replace(tempDir, ":", "_", -1)

--- a/readme.adoc
+++ b/readme.adoc
@@ -3,11 +3,16 @@
 image:https://badges.gitter.im/ngageoint/seed.svg[link="https://gitter.im/ngageoint/seed?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
 image:https://travis-ci.org/ngageoint/seed-cli.svg?branch=master[link="https://travis-ci.org/ngageoint/seed-cli"]
 
+:seed-user-guide-url: https://ngageoint.github.io/seed-cli
+
 //# tag::intro[]
 The Seed team provides a fully featured Command-Line Interface (CLI) for algorithm developers looking to offer Seed
 compliant packaging of their jobs. Using the CLI will enable you to quickly iterate without getting bogged down
 learning how to interface directly with the underlying container technologies (Docker). It also simplifies the process
 of attaching Seed metadata to your algorithm prior to publish.
+
+The following sections provide a brief overview of the most commonly used Seed CLI commands.
+For more detailed explanations, refer to the Seed {seed-user-guide-url}[user guide].
 //# end::intro[]
 
 == Usage


### PR DESCRIPTION
Remove debugging information from CLI output and add a link from the readme to the Seed user guide. Fixes #236 