### PR TITLE
Fix example seed run command in seed build output

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -136,7 +136,7 @@ func DockerBuild(jobDirectory, version, username, password, manifest, dockerfile
 	if seed.Job.Interface.Inputs.Json != nil {
 		for _, f := range seed.Job.Interface.Inputs.Json {
 			normalName := util.GetNormalizedVariable(f.Name)
-			jsonStr = fmt.Sprintf("%s-j %s=<setting> ", jsonStr, normalName)
+			jsonStr = fmt.Sprintf("%s-j %s=<json> ", jsonStr, normalName)
 		}
 	}
 
@@ -158,7 +158,7 @@ func DockerBuild(jobDirectory, version, username, password, manifest, dockerfile
 	util.PrintUtil("INFO: Successfully built image. This image can be published with the following command:\n")
 	util.PrintUtil("seed publish -in %s -r my.registry.address\n", imageName)
 	util.PrintUtil("This image can be run with the following command:\n")
-	runCmd := util.CleanString("seed run -rm -in %s %s %s %s-o <outdir>", imageName, inputStr, settingStr, mountStr)
+	runCmd := util.CleanString("seed run -rm -in %s %s %s %s %s-o <outdir>", imageName, inputStr, jsonStr, settingStr, mountStr)
 	util.PrintUtil("%s\n", runCmd)
 
 	return imageName, nil

--- a/commands/build.go
+++ b/commands/build.go
@@ -132,14 +132,15 @@ func DockerBuild(jobDirectory, version, username, password, manifest, dockerfile
 		}
 	}
 
-	settingStr := ""
+	jsonStr := ""
 	if seed.Job.Interface.Inputs.Json != nil {
 		for _, f := range seed.Job.Interface.Inputs.Json {
 			normalName := util.GetNormalizedVariable(f.Name)
-			settingStr = fmt.Sprintf("%s-e %s=<setting> ", settingStr, normalName)
+			jsonStr = fmt.Sprintf("%s-j %s=<setting> ", jsonStr, normalName)
 		}
 	}
 
+	settingStr := ""
 	if seed.Job.Interface.Settings != nil {
 		for _, f := range seed.Job.Interface.Settings {
 			normalName := util.GetNormalizedVariable(f.Name)
@@ -159,7 +160,6 @@ func DockerBuild(jobDirectory, version, username, password, manifest, dockerfile
 	util.PrintUtil("This image can be run with the following command:\n")
 	runCmd := util.CleanString("seed run -rm -in %s %s %s %s-o <outdir>", imageName, inputStr, settingStr, mountStr)
 	util.PrintUtil("%s\n", runCmd)
-	util.PrintUtil("seed run -rm -in %s %s %s %s-o <outdir>\n", imageName, inputStr, settingStr, mountStr)
 
 	return imageName, nil
 }

--- a/guide/example/Dockerfile
+++ b/guide/example/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-alpine
 
-RUN apk add build-base python-dev py-pip jpeg-dev zlib-dev
+RUN apk add build-base python3-dev py-pip jpeg-dev zlib-dev
 ENV LIBRARY_PATH=/lib:/usr/lib
 
 RUN pip install --upgrade pip && \

--- a/guide/index.adoc
+++ b/guide/index.adoc
@@ -496,7 +496,7 @@ Successfully tagged image-rotate-1.0.0-seed:1.0.0
 INFO: Successfully built image. This image can be published with the following command:
 seed publish -in image-rotate-1.0.0-seed:1.0.0 -r my.registry.address
 This image can be run with the following command:
-seed run -rm -in image-rotate-1.0.0-seed:1.0.0 -i INPUT_FILE=<file> -j DEGREES=<setting> -o <outdir>
+seed run -rm -in image-rotate-1.0.0-seed:1.0.0 -i INPUT_FILE=<file> -j DEGREES=<json> -o <outdir>
 ```
 
 Let's address the warning regarding disk resource by updating our manifest with a third object in the `job.resources.scalar` array:
@@ -552,7 +552,7 @@ With a complete Seed image now created, we can now run our job using the Seed im
 The last line of the console output shows us how we can use the Seed CLI to run our Seed job:
 
 ```
-seed run -rm -in image-rotate-1.0.0-seed:1.0.0 -i INPUT_FILE=<file> -j DEGREES=<setting>  -o <outdir>
+seed run -rm -in image-rotate-1.0.0-seed:1.0.0 -i INPUT_FILE=<file> -j DEGREES=<json> -o <outdir>
 ```
 
 === Run

--- a/guide/index.adoc
+++ b/guide/index.adoc
@@ -496,8 +496,7 @@ Successfully tagged image-rotate-1.0.0-seed:1.0.0
 INFO: Successfully built image. This image can be published with the following command:
 seed publish -in image-rotate-1.0.0-seed:1.0.0 -r my.registry.address
 This image can be run with the following command:
-seed run -rm -in image-rotate-1.0.0-seed:1.0.0 -i INPUT_FILE=<file> -e DEGREES=<setting> -o <outdir>
-seed run -rm -in image-rotate-1.0.0-seed:1.0.0 -i INPUT_FILE=<file>  -e DEGREES=<setting>  -o <outdir>
+seed run -rm -in image-rotate-1.0.0-seed:1.0.0 -i INPUT_FILE=<file> -j DEGREES=<setting> -o <outdir>
 ```
 
 Let's address the warning regarding disk resource by updating our manifest with a third object in the `job.resources.scalar` array:
@@ -553,7 +552,7 @@ With a complete Seed image now created, we can now run our job using the Seed im
 The last line of the console output shows us how we can use the Seed CLI to run our Seed job:
 
 ```
-seed run -rm -in image-rotate-1.0.0-seed:1.0.0 -i INPUT_FILE=<file>  -j DEGREES=<setting>  -o <outdir>
+seed run -rm -in image-rotate-1.0.0-seed:1.0.0 -i INPUT_FILE=<file> -j DEGREES=<setting>  -o <outdir>
 ```
 
 === Run


### PR DESCRIPTION
Correctly display JSON inputs with the `-j` flag in example `seed run` command produced by output of `seed build` command and update the user guide accordingly. Fixes #238.

Also fixed a dependency in the Dockerfile.

